### PR TITLE
feat(queue): retry with logging

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "http-proxy-middleware": "^3.0.5",
         "ioredis": "^5.4.1",
         "node-fetch": "^3.3.2",
+        "p-retry": "^6.2.1",
         "pino-http": "^10.5.0"
       },
       "devDependencies": {
@@ -714,6 +715,12 @@
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/retry": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.2.tgz",
+      "integrity": "sha512-XISRgDJ2Tc5q4TRqvgJtzsRkFYNJzZrhTdtMoGVBttwzzQJkPnS3WWTFc7kuDRoPtPakl+T+OfdEUjYJj7Jbow==",
       "license": "MIT"
     },
     "node_modules/@types/send": {
@@ -1648,6 +1655,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-network-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-network-error/-/is-network-error-1.1.0.tgz",
+      "integrity": "sha512-tUdRRAnhT+OtCZR/LxZelH/C7QtjtFrTu5tXCA8pl55eTUElUHT+GPYV8MBMBvea/j+NxQqVt3LbWMRir7Gx9g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -1934,6 +1953,23 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/p-retry": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-6.2.1.tgz",
+      "integrity": "sha512-hEt02O4hUct5wtwg4H4KcWgDdm+l1bOaEy/hWzd8xtXB9BqxTWBBhb+2ImAtH4Cv4rPjV76xN3Zumqk3k3AhhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/retry": "0.12.2",
+        "is-network-error": "^1.0.0",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=16.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -2134,6 +2170,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/safe-buffer": {

--- a/package.json
+++ b/package.json
@@ -21,12 +21,13 @@
     "http-proxy-middleware": "^3.0.5",
     "ioredis": "^5.4.1",
     "node-fetch": "^3.3.2",
+    "p-retry": "^6.2.1",
     "pino-http": "^10.5.0"
   },
   "devDependencies": {
     "@types/express": "^5.0.3",
     "@types/node": "^24.2.1",
-    "typescript": "^5.4.0",
-    "tsx": "^4.7.0"
+    "tsx": "^4.7.0",
+    "typescript": "^5.4.0"
   }
 }

--- a/src/connectors/shopify.ts
+++ b/src/connectors/shopify.ts
@@ -66,7 +66,7 @@ export const shopifyConnector: Connector = {
       }))
     };
     // push to queue to avoid webhook timeout
-    await orderQueue.add("order", jenniOrder);
+    await orderQueue.add("forward-order", jenniOrder);
     return jenniOrder;
   },
 

--- a/src/queue.ts
+++ b/src/queue.ts
@@ -1,15 +1,28 @@
 import { Queue, Worker } from "bullmq";
 import Redis from "ioredis";
+import pRetry from "p-retry";
+import pino from "pino";
 import { submitOrder } from "./core/order.js";
 
 const connection = new Redis(process.env.REDIS_URL ?? "");
+const logger = pino();
 
 export const orderQueue = new Queue("orders", { connection });
 
+const RETRY_CONFIG = {
+  retries: 5,
+  factor: 2,
+  minTimeout: 500,
+  maxTimeout: 4000
+};
+
 new Worker(
   "orders",
-  async job => {
-    await submitOrder(job.data);
+  {
+    "forward-order": async job => {
+      await pRetry(() => submitOrder(job.data), RETRY_CONFIG);
+      logger.info({ order_id: job.data.orderId });
+    }
   },
   { connection }
 );


### PR DESCRIPTION
## Summary
- add p-retry with backoff to submitOrder worker
- log order_id after successful forwarding
- rename queue job to "forward-order" for clarity

## Testing
- `npm test` (fails: Domain forbidden)
- `npm run build` (fails: Option 'allowImportingTsExtensions' can only be used when either 'noEmit' or 'emitDeclarationOnly' is set.)

------
https://chatgpt.com/codex/tasks/task_e_68b06a8f98b8832cb1c4012899d79bed